### PR TITLE
Allow multiple namespaces

### DIFF
--- a/classes/SleepEnvironmentBuilder.php
+++ b/classes/SleepEnvironmentBuilder.php
@@ -41,9 +41,9 @@ class SleepEnvironmentBuilder
 {
 
     /**
-     * @var string The namespace for the mock environment.
+     * @var array The namespaces for the mock environment.
      */
-    private $namespace;
+    private $namespaces;
 
     /**
      * @var mixed the timestamp.
@@ -51,14 +51,14 @@ class SleepEnvironmentBuilder
     private $timestamp;
 
     /**
-     * Sets the namespace for the mock environment.
+     * Add a namespace for the mock environment.
      *
-     * @param string $namespace The namespace for the mock environment.
+     * @param string $namespace A namespace for the mock environment.
      * @return SleepEnvironmentBuilder
      */
-    public function setNamespace($namespace)
+    public function addNamespace($namespace)
     {
-        $this->namespace = $namespace;
+        $this->namespaces[] = $namespace;
         return $this;
     }
 
@@ -86,38 +86,46 @@ class SleepEnvironmentBuilder
     public function build()
     {
         $environment = new MockEnvironment();
-
         $builder = new MockBuilder();
-        $builder->setNamespace($this->namespace);
 
-        // microtime() mock
-        $microtime = new FixedMicrotimeFunction($this->timestamp);
-        $builder->setName("microtime")
+        $incrementables = [];
+        foreach ($this->namespaces as $namespace) {
+            $builder->setNamespace($namespace);
+
+            // microtime() mock
+            $microtime = new FixedMicrotimeFunction($this->timestamp);
+            $builder->setName("microtime")
                 ->setFunctionProvider($microtime);
-        $environment->addMock($builder->build());
+            $environment->addMock($builder->build());
 
-        // time() mock
-        $builder->setName("time")
+            // time() mock
+            $builder->setName("time")
                 ->setFunction([$microtime, "getTime"]);
-        $environment->addMock($builder->build());
+            $environment->addMock($builder->build());
 
-        // date() mock
-        $date = new FixedDateFunction($this->timestamp);
-        $builder->setName("date")
-                ->setFunctionProvider($date);
-        $environment->addMock($builder->build());
+            // date() mock
+            $date = new FixedDateFunction($this->timestamp);
+            $builder->setName("date")
+                    ->setFunctionProvider($date);
+            $environment->addMock($builder->build());
 
-        $incrementables = [$microtime, $date];
+            $incrementables[] = $microtime;
+            $incrementables[] = $date;
+        }
 
-        // sleep() mock
-        $builder->setName("sleep")
+        // Need a complete list of $incrementables.
+        foreach ($this->namespaces as $namespace) {
+            $builder->setNamespace($namespace);
+            // sleep() mock
+            $builder->setName("sleep")
                 ->setFunctionProvider(new SleepFunction($incrementables));
-        $environment->addMock($builder->build());
+            $environment->addMock($builder->build());
 
-        // usleep() mock
-        $builder->setName("usleep")
+            // usleep() mock
+            $builder->setName("usleep")
                 ->setFunctionProvider(new UsleepFunction($incrementables));
-        $environment->addMock($builder->build());
+            $environment->addMock($builder->build());
+        }
 
         return $environment;
     }


### PR DESCRIPTION
Hi Markus,

If we have `date()` and `sleep()` calls in several namespaces, then current `SleepEnvironmentBuilder` implementation is limited: my need is to be able to increment `A\date()` after a call to `B\sleep()`.

Here is a possibility of evolution of `SleepEnvironmentBuilder` class.
An example of use:

```php
$builder = new SleepEnvironmentBuilder();
$builder
    ->addNamespace('A\\B')
    ->addNamespace('A\\B\\C')
    ->setTimestamp(strtotime('2030-01-01 00:00:00'));
```

Regards,
Geoffroy
