### PR TITLE
Allow PHPUnit 5 to be compatible with PHP7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpunit/php-text-template": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4"
+        "phpunit/phpunit": "^4|^5"
     },
     "replace": {
         "malkusch/php-mock": "*"


### PR DESCRIPTION
In PHP 7 you need newly released PHPUnit 5 to be fully compatible with it, so when you use php-mock (as I do in my project), it requires PHPUnit ^4, what prevents you from fulfilling the dependencies during composer install.

And the php-mock build is tested on Travis against PHP 7, so no problem should occur with the update.