### PR TITLE
Added PHPUnit 8 support

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,15 @@
+<?php
+
+use PHPUnit\Runner\Version;
+
+// Compatibility with PHPUnit 8.0
+// We need to use "magic" trait \phpmock\TestCaseTrait
+// and instead of setUp/tearDown method in test case
+// we should have setUpCompat/tearDownCompat.
+if (class_exists(Version::class)
+    && version_compare(Version::id(), '8.0.0') >= 0
+) {
+    class_alias(\phpmock\TestCaseTypeHintTrait::class, \phpmock\TestCaseTrait::class);
+} else {
+    class_alias(\phpmock\TestCaseNoTypeHintTrait::class, \phpmock\TestCaseTrait::class);
+}

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,15 @@
     "autoload": {
         "psr-4": {
             "phpmock\\": ["classes/", "tests/"]
-        }
+        },
+        "files": ["autoload.php"]
     },
     "require": {
-        "php": ">=5.6",
+        "php": "^5.6 || ^7.0",
         "phpunit/php-text-template": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0"
     },
     "replace": {
         "malkusch/php-mock": "*"

--- a/tests/AbstractMockTest.php
+++ b/tests/AbstractMockTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class AbstractMockTest extends TestCase
 {
+    use TestCaseTrait;
 
     /**
      * Disable all mocks.
@@ -37,7 +38,7 @@ abstract class AbstractMockTest extends TestCase
      */
     abstract protected function defineFunction($namespace, $functionName);
 
-    protected function tearDown()
+    protected function tearDownCompat()
     {
         parent::tearDown();
 
@@ -102,13 +103,14 @@ abstract class AbstractMockTest extends TestCase
     /**
      * Tests failing enabling an already enabled mock.
      *
-     * @expectedException phpmock\MockEnabledException
      * @test
      */
     public function testFailEnable()
     {
         $name = "testFailEnable";
         $this->mockFunction(__NAMESPACE__, $name, "sqrt");
+
+        $this->expectException(MockEnabledException::class);
         $this->mockFunction(__NAMESPACE__, $name, "sqrt");
     }
     

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -7,6 +7,8 @@ use phpmock\MockBuilder;
 use phpmock\MockRegistry;
 use phpmock\functions\FixedValueFunction;
 use phpmock\environment\SleepEnvironmentBuilder;
+use phpmock\TestCaseTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the example from the documentation.
@@ -15,10 +17,11 @@ use phpmock\environment\SleepEnvironmentBuilder;
  * @link bitcoin:1335STSwu9hST4vcMRppEPgENMHD2r1REK Donations
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  */
-class ExampleTest extends \PHPUnit_Framework_TestCase
+class ExampleTest extends TestCase
 {
+    use TestCaseTrait;
     
-    protected function tearDown()
+    protected function tearDownCompat()
     {
         MockRegistry::getInstance()->unregisterAll();
     }
@@ -85,8 +88,6 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
     
     /**
      * Tests the example from the documentation.
-     *
-     * @expectedException Exception
      */
     public function testExample4()
     {
@@ -96,6 +97,7 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
         $mock = new Mock(__NAMESPACE__, "time", $function);
         $mock->enable();
         try {
+            $this->expectException(\Exception::class);
             time();
         } finally {
             $mock->disable();
@@ -117,6 +119,6 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
             }
         );
         $time->enable();
-        assert(3 == time());
+        $this->assertSame(3, time());
     }
 }

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -3,6 +3,7 @@
 namespace phpmock;
 
 use phpmock\functions\FixedValueFunction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests MockBuilder.
@@ -12,7 +13,7 @@ use phpmock\functions\FixedValueFunction;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see MockBuilder
  */
-class MockBuilderTest extends \PHPUnit_Framework_TestCase
+class MockBuilderTest extends TestCase
 {
     
     /**

--- a/tests/MockCaseInsensitivityTest.php
+++ b/tests/MockCaseInsensitivityTest.php
@@ -3,6 +3,7 @@
 namespace phpmock;
 
 use phpmock\functions\FixedValueFunction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests Mock's case insensitivity.
@@ -12,15 +13,16 @@ use phpmock\functions\FixedValueFunction;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see Mock
  */
-class MockCaseInsensitivityTest extends \PHPUnit_Framework_TestCase
+class MockCaseInsensitivityTest extends TestCase
 {
+    use TestCaseTrait;
     
     /**
      * @var Mock
      */
     private $mock;
     
-    protected function tearDown()
+    protected function tearDownCompat()
     {
         if (isset($this->mock)) {
             $this->mock->disable();
@@ -30,7 +32,6 @@ class MockCaseInsensitivityTest extends \PHPUnit_Framework_TestCase
     /**
      * @param string $mockName  The mock function name.
      *
-     * @expectedException phpmock\MockEnabledException
      * @dataProvider provideTestCaseSensitivity
      * @test
      */
@@ -45,6 +46,7 @@ class MockCaseInsensitivityTest extends \PHPUnit_Framework_TestCase
         $this->mock->enable();
         
         $failingMock = $builder->setName($mockName)->build();
+        $this->expectException(MockEnabledException::class);
         $failingMock->enable();
     }
     

--- a/tests/MockDefiningOrderTest.php
+++ b/tests/MockDefiningOrderTest.php
@@ -3,6 +3,7 @@
 namespace phpmock;
 
 use phpmock\functions\FixedValueFunction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the ordering of the mock creation.
@@ -12,15 +13,16 @@ use phpmock\functions\FixedValueFunction;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see Mock
  */
-class MockDefiningOrderTest extends \PHPUnit_Framework_TestCase
+class MockDefiningOrderTest extends TestCase
 {
+    use TestCaseTrait;
 
     /**
      * @var Mock The mock.
      */
     private $mock;
 
-    protected function tearDown()
+    protected function tearDownCompat()
     {
         if (isset($this->mock)) {
             $this->mock->disable();

--- a/tests/MockNamespaceTest.php
+++ b/tests/MockNamespaceTest.php
@@ -6,6 +6,8 @@ namespace phpmock\test;
 use phpmock\Mock;
 use phpmock\MockBuilder;
 use phpmock\functions\FixedValueFunction;
+use phpmock\TestCaseTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests Mock in a different namespace.
@@ -15,8 +17,9 @@ use phpmock\functions\FixedValueFunction;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see Mock
  */
-class MockNamespaceTest extends \PHPUnit_Framework_TestCase
+class MockNamespaceTest extends TestCase
 {
+    use TestCaseTrait;
     
     /**
      * @var Mock
@@ -28,7 +31,7 @@ class MockNamespaceTest extends \PHPUnit_Framework_TestCase
      */
     private $builder;
     
-    protected function setUp()
+    protected function setUpCompat()
     {
         $this->builder = new MockBuilder();
         $this->builder
@@ -36,7 +39,7 @@ class MockNamespaceTest extends \PHPUnit_Framework_TestCase
                 ->setFunctionProvider(new FixedValueFunction(1234));
     }
     
-    protected function tearDown()
+    protected function tearDownCompat()
     {
         if (! empty($this->mock)) {
             $this->mock->disable();

--- a/tests/TestCaseNoTypeHintTrait.php
+++ b/tests/TestCaseNoTypeHintTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace phpmock;
+
+/**
+ * @internal
+ */
+trait TestCaseNoTypeHintTrait
+{
+    protected function setUp()
+    {
+        if (method_exists($this, 'setUpCompat')) {
+            $this->setUpCompat();
+        }
+    }
+
+    protected function tearDown()
+    {
+        if (method_exists($this, 'tearDownCompat')) {
+            $this->tearDownCompat();
+        }
+    }
+}

--- a/tests/TestCaseTypeHintTrait.php
+++ b/tests/TestCaseTypeHintTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace phpmock;
+
+/**
+ * @internal
+ */
+trait TestCaseTypeHintTrait
+{
+    protected function setUp() : void
+    {
+        if (method_exists($this, 'setUpCompat')) {
+            $this->setUpCompat();
+        }
+    }
+
+    protected function tearDown() : void
+    {
+        if (method_exists($this, 'tearDownCompat')) {
+            $this->tearDownCompat();
+        }
+    }
+}

--- a/tests/environment/MockEnvironmentTest.php
+++ b/tests/environment/MockEnvironmentTest.php
@@ -5,6 +5,8 @@ namespace phpmock\environment;
 use phpmock\Mock;
 use phpmock\MockBuilder;
 use phpmock\functions\FixedValueFunction;
+use phpmock\TestCaseTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests MockEnvironment.
@@ -14,15 +16,16 @@ use phpmock\functions\FixedValueFunction;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see MockEnvironment
  */
-class MockEnvironmentTest extends \PHPUnit_Framework_TestCase
+class MockEnvironmentTest extends TestCase
 {
+    use TestCaseTrait;
     
     /**
      * @var MockEnvironment The tested environment.
      */
     private $environment;
     
-    protected function setUp()
+    protected function setUpCompat()
     {
         $builder = new MockBuilder();
         $builder->setNamespace(__NAMESPACE__)
@@ -33,7 +36,7 @@ class MockEnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->environment->addMock($builder->setName("rand")->build());
     }
 
-    protected function tearDown()
+    protected function tearDownCompat()
     {
         $this->environment->disable();
     }

--- a/tests/environment/SleepEnvironmentBuilderTest.php
+++ b/tests/environment/SleepEnvironmentBuilderTest.php
@@ -2,6 +2,9 @@
 
 namespace phpmock\environment;
 
+use phpmock\TestCaseTrait;
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests SleepEnvironmentBuilder.
  *
@@ -10,15 +13,16 @@ namespace phpmock\environment;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see SleepEnvironmentBuilder
  */
-class SleepEnvironmentBuilderTest extends \PHPUnit_Framework_TestCase
+class SleepEnvironmentBuilderTest extends TestCase
 {
+    use TestCaseTrait;
     
     /**
      * @var MockEnvironment The build environment.
      */
     private $environment;
     
-    protected function setUp()
+    protected function setUpCompat()
     {
         $builder = new SleepEnvironmentBuilder();
         $builder->addNamespace(__NAMESPACE__)
@@ -28,7 +32,7 @@ class SleepEnvironmentBuilderTest extends \PHPUnit_Framework_TestCase
         $this->environment->enable();
     }
 
-    protected function tearDown()
+    protected function tearDownCompat()
     {
         $this->environment->disable();
     }

--- a/tests/functions/AbstractSleepFunctionTest.php
+++ b/tests/functions/AbstractSleepFunctionTest.php
@@ -2,6 +2,8 @@
 
 namespace phpmock\functions;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests AbstractSleepFunction and all its implementations.
  *
@@ -10,7 +12,7 @@ namespace phpmock\functions;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see AbstractSleepFunction
  */
-class AbstractSleepFunctionTest extends \PHPUnit_Framework_TestCase
+class AbstractSleepFunctionTest extends TestCase
 {
     
     /**

--- a/tests/functions/FixedDateFunctionTest.php
+++ b/tests/functions/FixedDateFunctionTest.php
@@ -2,6 +2,8 @@
 
 namespace phpmock\functions;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests FixedDateFunction.
  *
@@ -10,7 +12,7 @@ namespace phpmock\functions;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see FixedDateFunction
  */
-class FixedDateFunctionTest extends \PHPUnit_Framework_TestCase
+class FixedDateFunctionTest extends TestCase
 {
 
     /**

--- a/tests/functions/FixedMicrotimeFunctionTest.php
+++ b/tests/functions/FixedMicrotimeFunctionTest.php
@@ -3,6 +3,7 @@
 namespace phpmock\functions;
 
 use phpmock\MockBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests FixedMicrotimeFunction.
@@ -12,7 +13,7 @@ use phpmock\MockBuilder;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see FixedMicrotimeFunction
  */
-class FixedMicrotimeFunctionTest extends \PHPUnit_Framework_TestCase
+class FixedMicrotimeFunctionTest extends TestCase
 {
     
     /**
@@ -92,11 +93,11 @@ class FixedMicrotimeFunctionTest extends \PHPUnit_Framework_TestCase
      * Tests exception for invalid argument in constructor.
      *
      * @test
-     * @expectedException \InvalidArgumentException
      * @dataProvider provideTestConstructFailsForInvalidArgument
      */
     public function testConstructFailsForInvalidArgument($timestamp)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new FixedMicrotimeFunction($timestamp);
     }
     

--- a/tests/functions/IncrementableTest.php
+++ b/tests/functions/IncrementableTest.php
@@ -2,6 +2,8 @@
 
 namespace phpmock\functions;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests Incrementable and all its implementations.
  *
@@ -10,7 +12,7 @@ namespace phpmock\functions;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see Incrementable
  */
-class IncrementableTest extends \PHPUnit_Framework_TestCase
+class IncrementableTest extends TestCase
 {
     
     /**

--- a/tests/functions/MicrotimeConverterTest.php
+++ b/tests/functions/MicrotimeConverterTest.php
@@ -2,6 +2,8 @@
 
 namespace phpmock\functions;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests MicrotimeConverter.
  *
@@ -10,7 +12,7 @@ namespace phpmock\functions;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see MicrotimeConverter
  */
-class MicrotimeConverterTest extends \PHPUnit_Framework_TestCase
+class MicrotimeConverterTest extends TestCase
 {
 
     /**

--- a/tests/generator/MockFunctionGeneratorTest.php
+++ b/tests/generator/MockFunctionGeneratorTest.php
@@ -2,6 +2,8 @@
 
 namespace phpmock\generator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests MockFunctionGenerator.
  *
@@ -10,7 +12,7 @@ namespace phpmock\generator;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see MockFunctionGenerator
  */
-class MockFunctionGeneratorTest extends \PHPUnit_Framework_TestCase
+class MockFunctionGeneratorTest extends TestCase
 {
 
     /**

--- a/tests/generator/ParameterBuilderTest.php
+++ b/tests/generator/ParameterBuilderTest.php
@@ -2,6 +2,8 @@
 
 namespace phpmock\generator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests ParameterBuilder.
  *
@@ -10,7 +12,7 @@ namespace phpmock\generator;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see ParameterBuilder
  */
-class ParameterBuilderTest extends \PHPUnit_Framework_TestCase
+class ParameterBuilderTest extends TestCase
 {
     
     /**


### PR DESCRIPTION
Added PHPUnit 8 support by adding internal use 'magic' trait. We need now to use `setUpCompat`/`tearDownCompat` methods instead to support many PHPUnit versions in the library.

