### PR TITLE
Fixes autoloader for PHPUnit 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
     "autoload": {
         "psr-4": {
             "phpmock\\": ["classes/", "tests/"]
-        },
+        }
+    },
+    "autoload-dev": {
         "files": ["autoload.php"]
     },
     "require": {

--- a/tests/AbstractMockTest.php
+++ b/tests/AbstractMockTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects.FoundWithSymbols
 
 namespace phpmock;
 

--- a/tests/AbstractMockTest.php
+++ b/tests/AbstractMockTest.php
@@ -4,6 +4,11 @@ namespace phpmock;
 
 use PHPUnit\Framework\TestCase;
 
+// When class is used in related repositories we need to add autoloader for PHPUnit 8 compatibility
+if (!trait_exists(TestCaseTrait::class)) {
+    require __DIR__ . '/../autoload.php';
+}
+
 /**
  * Common tests for mocks.
  *


### PR DESCRIPTION
Fixes #25

Autoloader was added in autoload section of composer, but in some cases
tests/ directory was exceluded from the package and then it breaks
autoloading.

/cc @meetmatt
What do you think about this solution? From what I've tested it works as expected, also with integration packages.