### PR TITLE
Correct the namespace of MockNamespaceTest

### DIFF
--- a/tests/MockNamespaceTest.php
+++ b/tests/MockNamespaceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // A different namespace
-namespace phpmock\test;
+namespace phpmock\tests;
 
 use phpmock\Mock;
 use phpmock\MockBuilder;

--- a/tests/MockNamespaceTest.php
+++ b/tests/MockNamespaceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // A different namespace
-namespace phpmock\tests;
+namespace phpmocktest;
 
 use phpmock\Mock;
 use phpmock\MockBuilder;


### PR DESCRIPTION
The namespace of MockNamespaceTest class did not comply with psr-4 autoloading standard. Leaving the class with incorrect namespace would cause it to not be autoloaded  in Composer v2.0.