### PR TITLE
Global namespace mocks

### DIFF
--- a/classes/Mock.php
+++ b/classes/Mock.php
@@ -64,9 +64,6 @@ class Mock implements Deactivatable
      */
     public function __construct($namespace, $name, callable $function)
     {
-        if (empty($namespace)) {
-            throw new InvalidArgumentException('Namespace should not be empty');
-        }
         if (empty($name)) {
             throw new InvalidArgumentException('Function name should not be empty');
         }

--- a/classes/generator/function.tpl
+++ b/classes/generator/function.tpl
@@ -1,17 +1,18 @@
-namespace {namespace};
+namespace {namespace} {
 
-use phpmock\generator\MockFunctionGenerator;
+    use phpmock\generator\MockFunctionGenerator;
 
-function {name}({signatureParameters})
-{
-    $arguments = [{bodyParameters}];
+    function {name}({signatureParameters})
+    {
+        $arguments = [{bodyParameters}];
 
-    $variadics = \array_slice(\func_get_args(), \count($arguments));
-    $arguments = \array_merge($arguments, $variadics);
+        $variadics = \array_slice(\func_get_args(), \count($arguments));
+        $arguments = \array_merge($arguments, $variadics);
 
-    return MockFunctionGenerator::call(
-        '{name}',
-        '{fqfn}',
-        $arguments
-    );
+        return MockFunctionGenerator::call(
+            '{name}',
+            '{fqfn}',
+            $arguments
+        );
+    }
 }


### PR DESCRIPTION
The [source article](http://www.schmengler-se.de/en/2011/03/php-mocking-built-in-functions-like-time-in-unit-tests/) referenced 7 years ago when PHP5.3 was new used the standard non-bracketed namespace declaration. If you use the bracketed one here you actually unlock global namespace mocks as well.

Specifically: `\function_call()` becomes mockable.