### PR TITLE
fix: Default value for properties

### DIFF
--- a/classes/generator/ParameterBuilder.php
+++ b/classes/generator/ParameterBuilder.php
@@ -17,12 +17,12 @@ class ParameterBuilder
     /**
      * @var string The signature's parameters.
      */
-    private $signatureParameters;
+    private $signatureParameters = '';
 
     /**
      * @var string The body's parameter access list.
      */
-    private $bodyParameters;
+    private $bodyParameters = '';
 
     /**
      * Builds the parameters for an existing function.

--- a/classes/generator/ParameterBuilder.php
+++ b/classes/generator/ParameterBuilder.php
@@ -17,7 +17,7 @@ class ParameterBuilder
     /**
      * @var string The signature's parameters.
      */
-    private $signatureParameters;
+    private $signatureParameters = '';
 
     /**
      * @var string The body's parameter access list.

--- a/classes/generator/ParameterBuilder.php
+++ b/classes/generator/ParameterBuilder.php
@@ -17,7 +17,7 @@ class ParameterBuilder
     /**
      * @var string The signature's parameters.
      */
-    private $signatureParameters = '';
+    private $signatureParameters;
 
     /**
      * @var string The body's parameter access list.

--- a/tests/generator/ParameterBuilderTest.php
+++ b/tests/generator/ParameterBuilderTest.php
@@ -124,6 +124,7 @@ class ParameterBuilderTest extends TestCase
         }
 
         $cases = [
+            ["", "", __NAMESPACE__ . "\\testDoesNotExist"],
             ["", "", __NAMESPACE__ . "\\testNoParameter"],
             ['$one', '$one', __NAMESPACE__ . "\\testOneParameter"],
             ['$one, $two', '$one, $two', __NAMESPACE__ . "\\testTwoParameters"],

--- a/tests/generator/ParameterBuilderTest.php
+++ b/tests/generator/ParameterBuilderTest.php
@@ -28,8 +28,8 @@ class ParameterBuilderTest extends TestCase
     {
         $builder = new ParameterBuilder();
         $builder->build($function);
-        $this->assertEquals($expectedSignature, $builder->getSignatureParameters());
-        $this->assertEquals($expectedBody, $builder->getBodyParameters());
+        $this->assertSame($expectedSignature, $builder->getSignatureParameters());
+        $this->assertSame($expectedBody, $builder->getBodyParameters());
     }
 
     /**


### PR DESCRIPTION
Related to: https://github.com/php-mock/php-mock-integration/pull/3

Setting default values on the properties, so we are getting in getters always strings as expected.
When we call `build` method on non-existent function and then use getters we are getting back `null`, but signature (PHPDocs) suggest we should be getting always string there.

/cc @rogervila