### PR TITLE
PHPUnit 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/php-text-template": "^1 || ^2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "replace": {


### PR DESCRIPTION
I noticed that PHPUnit 10 was not yet supported in `composer.json` where I reckon it runs perfectly fine without requiring further modification