### PR TITLE
feat: Support PHPUnit 10

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/classes/functions/FixedDateFunction.php
+++ b/classes/functions/FixedDateFunction.php
@@ -51,6 +51,6 @@ class FixedDateFunction implements FunctionProvider, Incrementable
 
     public function increment($increment)
     {
-        $this->timestamp += $increment;
+        $this->timestamp += (int) $increment;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/php-text-template": "^1 || ^2 || ^3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10",
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     },
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
-        "phpunit/php-text-template": "^1 || ^2"
+        "phpunit/php-text-template": "^1 || ^2 || ^3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "replace": {

--- a/tests/AbstractMockTestCase.php
+++ b/tests/AbstractMockTestCase.php
@@ -17,7 +17,7 @@ if (!trait_exists(TestCaseTrait::class)) {
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see Mock
  */
-abstract class AbstractMockTest extends TestCase
+abstract class AbstractMockTestCase extends TestCase
 {
     use TestCaseTrait;
 
@@ -327,7 +327,7 @@ abstract class AbstractMockTest extends TestCase
      *
      * @return array Test cases.
      */
-    public function provideTestBackupStaticAttributes()
+    public static function provideTestBackupStaticAttributes()
     {
         return [
             [], [], [], [], [], [], [], [], [], [], [], []

--- a/tests/MockCaseInsensitivityTest.php
+++ b/tests/MockCaseInsensitivityTest.php
@@ -78,7 +78,7 @@ class MockCaseInsensitivityTest extends TestCase
      *
      * @return string[][] Test cases.
      */
-    public function provideTestCaseSensitivity()
+    public static function provideTestCaseSensitivity()
     {
         return [
             ["TIME"],

--- a/tests/MockTest.php
+++ b/tests/MockTest.php
@@ -10,7 +10,7 @@ namespace phpmock;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see Mock
  */
-class MockTest extends AbstractMockTest
+class MockTest extends AbstractMockTestCase
 {
     protected function defineFunction($namespace, $functionName)
     {

--- a/tests/environment/SleepEnvironmentBuilderTest.php
+++ b/tests/environment/SleepEnvironmentBuilderTest.php
@@ -102,7 +102,7 @@ class SleepEnvironmentBuilderTest extends TestCase
      *
      * @return int[][] Test cases.
      */
-    public function provideTestUsleep()
+    public static function provideTestUsleep()
     {
         return [
             [1000],

--- a/tests/functions/AbstractSleepFunctionTest.php
+++ b/tests/functions/AbstractSleepFunctionTest.php
@@ -57,7 +57,7 @@ class AbstractSleepFunctionTest extends TestCase
      *
      * @return array Test cases.
      */
-    public function provideTestSleepIncrementation()
+    public static function provideTestSleepIncrementation()
     {
         return [
             [new SleepFunction(), 1, 1],

--- a/tests/functions/FixedMicrotimeFunctionTest.php
+++ b/tests/functions/FixedMicrotimeFunctionTest.php
@@ -105,7 +105,7 @@ class FixedMicrotimeFunctionTest extends TestCase
      *
      * @return array Test cases.
      */
-    public function provideTestConstructFailsForInvalidArgument()
+    public static function provideTestConstructFailsForInvalidArgument()
     {
         return [
             [true],
@@ -134,7 +134,7 @@ class FixedMicrotimeFunctionTest extends TestCase
      *
      * @return array
      */
-    public function provideTestConstruct()
+    public static function provideTestConstruct()
     {
         return [
             ["0.00000001 1", 1.00000001],

--- a/tests/functions/IncrementableTest.php
+++ b/tests/functions/IncrementableTest.php
@@ -40,7 +40,7 @@ class IncrementableTest extends TestCase
      *
      * @return array Test cases.
      */
-    public function provideTestIncrement()
+    public static function provideTestIncrement()
     {
         $getFixedValue = function (FixedValueFunction $function) {
             return call_user_func($function->getCallable());

--- a/tests/functions/MicrotimeConverterTest.php
+++ b/tests/functions/MicrotimeConverterTest.php
@@ -49,7 +49,7 @@ class MicrotimeConverterTest extends TestCase
      *
      * @return array
      */
-    public function provideFloatAndStrings()
+    public static function provideFloatAndStrings()
     {
         return [
             [1.0,        "0.00000000 1"],

--- a/tests/generator/MockFunctionGeneratorTest.php
+++ b/tests/generator/MockFunctionGeneratorTest.php
@@ -34,7 +34,7 @@ class MockFunctionGeneratorTest extends TestCase
      *
      * @return The test cases.
      */
-    public function provideTestRemoveDefaultArguments()
+    public static function provideTestRemoveDefaultArguments()
     {
         return[
             [[], []],

--- a/tests/generator/ParameterBuilderTest.php
+++ b/tests/generator/ParameterBuilderTest.php
@@ -37,7 +37,7 @@ class ParameterBuilderTest extends TestCase
      *
      * @return string[][][] The test cases.
      */
-    public function provideTestBuild()
+    public static function provideTestBuild()
     {
         // @codingStandardsIgnoreStart
 
@@ -84,7 +84,7 @@ class ParameterBuilderTest extends TestCase
         function testCombined($one, &$two, $three = 3, &$four = 4)
         {
         }
-        
+
         function testPHPVariadics1(...$one)
         {
         }
@@ -113,7 +113,7 @@ class ParameterBuilderTest extends TestCase
                }'
           );
         }
-        
+
         // @codingStandardsIgnoreEnd
 
         // PHP8.0+ has a different signature wording.

--- a/tests/spy/SpyTest.php
+++ b/tests/spy/SpyTest.php
@@ -3,7 +3,7 @@
 namespace phpmock\spy;
 
 use phpmock\Mock;
-use phpmock\AbstractMockTest;
+use phpmock\AbstractMockTestCase;
 
 /**
  * Tests the Spy.
@@ -13,7 +13,7 @@ use phpmock\AbstractMockTest;
  * @license http://www.wtfpl.net/txt/copying/ WTFPL
  * @see Spy
  */
-class SpyTest extends AbstractMockTest
+class SpyTest extends AbstractMockTestCase
 {
     protected function defineFunction($namespace, $functionName)
     {
@@ -56,7 +56,7 @@ class SpyTest extends AbstractMockTest
      *
      * @return array Test cases for testGetInvocations.
      */
-    public function provideTestGetInvocations()
+    public static function provideTestGetInvocations()
     {
         eval("function testGetInvocations_noParameters() { return 123; }");
         eval("function testGetInvocations_oneParameter(\$a) { return \$a + 1; }");


### PR DESCRIPTION
Makes it possible for consumers to use PHPUnit 10 by allowing `phpunit/php-text-template: ^3` (which only requires PHP 8.1+ from now on, see https://github.com/sebastianbergmann/php-text-template/blob/3.0.0/ChangeLog.md)

Additionally it allows PHPUnit 10 as a dev dependency and I fixed the reported warnings and deprecations, making sure it still works fine with e.g. PHP 7.4 and PHPUnit 9. I didn't go down further, I was assuming CI will be checking this if it's important, but the changes don't indicate that something was added that only a higher PHPUnit provides.