### PR TITLE
Add "testing" keyword to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "php-mock/php-mock",
     "type": "library",
     "description": "PHP-Mock can mock built-in PHP functions (e.g. time()). PHP-Mock relies on PHP's namespace fallback policy. No further extension is needed.",
-    "keywords": ["mock", "stub", "test double", "function", "test", "TDD", "BDD"],
+    "keywords": ["mock", "stub", "test double", "function", "test", "testing", "TDD", "BDD"],
     "homepage": "https://github.com/php-mock/php-mock",
     "license": "WTFPL",
     "authors": [


### PR DESCRIPTION
A colleague recently made a mistake and required one of the packages from php-mock/ as a non-dev dependency.

Since composer is checking for existence of a couple of specific keywords and, when found, suggests to install the package as dev dependency instead then, I suggest to add "testing" here to trigger that feature and avoid that other people make the mistake my colleague did :)

See https://github.com/composer/composer/blob/2.5.8/src/Composer/Command/RequireCommand.php#L235

If you like this, I would just add the same to all other packages too. WDYT?