### PR TITLE
feat: Support PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     },
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
-        "phpunit/php-text-template": "^1 || ^2 || ^3"
+        "phpunit/php-text-template": "^1 || ^2 || ^3 || ^4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10.0",
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "squizlabs/php_codesniffer": "^3.8"
     },
     "replace": {

--- a/tests/AbstractMockTestCase.php
+++ b/tests/AbstractMockTestCase.php
@@ -52,8 +52,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests mocking a function without parameters.
-     *
-     * @test
      */
     public function testMockFunctionWithoutParameters()
     {
@@ -65,8 +63,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests mocking a previously mocked function again.
-     *
-     * @test
      * @depends testMockFunctionWithoutParameters
      */
     public function testRedefine()
@@ -79,8 +75,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests mocking a function without parameters.
-     *
-     * @test
      */
     public function testMockFunctionWithParameters()
     {
@@ -92,8 +86,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests mocking of an undefined function.
-     *
-     * @test
      */
     public function testUndefinedFunction()
     {
@@ -107,8 +99,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests failing enabling an already enabled mock.
-     *
-     * @test
      */
     public function testFailEnable()
     {
@@ -121,8 +111,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests passing by value.
-     *
-     * @test
      */
     public function testPassingByValue()
     {
@@ -136,8 +124,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Test passing by reference.
-     *
-     * @test
      */
     public function testPassingByReference()
     {
@@ -161,8 +147,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests that the mock preserves the default argument
-     *
-     * @test
      */
     public function testPreserveArgumentDefaultValue()
     {
@@ -189,8 +173,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests that the disabled mock uses the default argument of the original function.
-     *
-     * @test
      * @depends testPreserveArgumentDefaultValue
      */
     public function testResetToDefaultArgumentOfOriginalFunction()
@@ -202,8 +184,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests some methods which use the varname "...".
-     *
-     * @test
      */
     public function testCVariadic()
     {
@@ -215,8 +195,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests some methods which use the varname "..." after a mock was defined.
-     *
-     * @test
      * @depends testCVariadic
      */
     public function testCVariadicReset()
@@ -227,8 +205,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Setup a mock for testDisable().
-     *
-     * @test
      */
     public function testDisableSetup()
     {
@@ -244,8 +220,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests disable().
-     *
-     * @test
      * @depends testDisableSetup
      */
     public function testDisable()
@@ -256,8 +230,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests mocking the function implicitely defines the function.
-     *
-     * @test
      */
     public function testImplicitDefine()
     {
@@ -270,8 +242,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests explicit function defining.
-     *
-     * @test
      */
     public function testExplicitDefine()
     {
@@ -311,8 +281,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests declaring repeatedly a mock with enabled backupStaticAttributes.
-     *
-     * @test
      * @backupStaticAttributes
      * @dataProvider provideTestBackupStaticAttributes
      */
@@ -336,8 +304,6 @@ abstract class AbstractMockTestCase extends TestCase
 
     /**
      * Tests the mock in a separate process.
-     *
-     * @test
      * @runInSeparateProcess
      */
     public function testRunInSeparateProcess()

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -28,8 +28,6 @@ class ExampleTest extends TestCase
 
     /**
      * Tests the example from the documentation.
-     *
-     * @test
      */
     public function testExample1()
     {
@@ -50,8 +48,6 @@ class ExampleTest extends TestCase
 
     /**
      * Tests the example from the documentation.
-     *
-     * @test
      */
     public function testExample2()
     {
@@ -68,8 +64,6 @@ class ExampleTest extends TestCase
 
     /**
      * Tests the example from the documentation.
-     *
-     * @test
      */
     public function testExample3()
     {
@@ -106,8 +100,6 @@ class ExampleTest extends TestCase
 
     /**
      * Tests the example from the documentation.
-     *
-     * @test
      */
     public function testExample5()
     {

--- a/tests/MockBuilderTest.php
+++ b/tests/MockBuilderTest.php
@@ -17,8 +17,6 @@ class MockBuilderTest extends TestCase
 {
     /**
      * Tests build().
-     *
-     * @test
      */
     public function testBuild()
     {

--- a/tests/MockCaseInsensitivityTest.php
+++ b/tests/MockCaseInsensitivityTest.php
@@ -33,7 +33,6 @@ class MockCaseInsensitivityTest extends TestCase
      * @param string $mockName  The mock function name.
      *
      * @dataProvider provideTestCaseSensitivity
-     * @test
      */
     public function testFailEnable($mockName)
     {
@@ -54,8 +53,6 @@ class MockCaseInsensitivityTest extends TestCase
      * Tests case insensitive mocks.
      *
      * @param string $mockName  The mock function name.
-     *
-     * @test
      * @dataProvider provideTestCaseSensitivity
      */
     public function testCaseSensitivity($mockName)

--- a/tests/MockDefiningOrderTest.php
+++ b/tests/MockDefiningOrderTest.php
@@ -52,7 +52,6 @@ class MockDefiningOrderTest extends TestCase
      * documentation can be updated.
      *
      * @link https://bugs.php.net/bug.php?id=68541 Bug #68541
-     * @test
      */
     public function testDefineBeforeFirstCallRestriction()
     {
@@ -86,8 +85,6 @@ class MockDefiningOrderTest extends TestCase
 
     /**
      * Tests defining the mock after calling the unqualified function name.
-     *
-     * @test
      */
     public function testDefiningAfterCallingUnqualified()
     {
@@ -109,8 +106,6 @@ class MockDefiningOrderTest extends TestCase
 
     /**
      * Tests defining the mock after calling the qualified function name.
-     *
-     * @test
      */
     public function testDefiningAfterCallingQualified()
     {

--- a/tests/MockNamespaceTest.php
+++ b/tests/MockNamespaceTest.php
@@ -49,8 +49,6 @@ class MockNamespaceTest extends TestCase
 
     /**
      * Tests defining mocks in a different namespace.
-     *
-     * @test
      * @dataprovider provideTestNamespace
      * @runInSeparateProcess
      */
@@ -65,8 +63,6 @@ class MockNamespaceTest extends TestCase
 
     /**
      * Tests redefining mocks in a different namespace.
-     *
-     * @test
      * @dataprovider provideTestNamespace
      */
     public function testRedefiningNamespaces()

--- a/tests/MockTest.php
+++ b/tests/MockTest.php
@@ -32,8 +32,6 @@ class MockTest extends AbstractMockTestCase
 
     /**
      * Tests enable().
-     *
-     * @test
      */
     public function testEnable()
     {
@@ -51,8 +49,6 @@ class MockTest extends AbstractMockTestCase
 
     /**
      * Tests disabling and enabling again.
-     *
-     * @test
      */
     public function testReenable()
     {
@@ -71,8 +67,6 @@ class MockTest extends AbstractMockTestCase
 
     /**
      * Tests disableAll().
-     *
-     * @test
      */
     public function testDisableAll()
     {

--- a/tests/environment/MockEnvironmentTest.php
+++ b/tests/environment/MockEnvironmentTest.php
@@ -43,8 +43,6 @@ class MockEnvironmentTest extends TestCase
 
     /**
      * Tests enable()
-     *
-     * @test
      */
     public function testEnable()
     {
@@ -56,8 +54,6 @@ class MockEnvironmentTest extends TestCase
 
     /**
      * Tests define()
-     *
-     * @test
      */
     public function testDefine()
     {
@@ -75,8 +71,6 @@ class MockEnvironmentTest extends TestCase
 
     /**
      * Tests disable()
-     *
-     * @test
      */
     public function testDisable()
     {

--- a/tests/environment/SleepEnvironmentBuilderTest.php
+++ b/tests/environment/SleepEnvironmentBuilderTest.php
@@ -39,8 +39,6 @@ class SleepEnvironmentBuilderTest extends TestCase
 
     /**
      * Tests mocking functions accross several namespaces.
-     *
-     * @test
      */
     public function testAddNamespace()
     {
@@ -63,8 +61,6 @@ class SleepEnvironmentBuilderTest extends TestCase
 
     /**
      * Tests sleep()
-     *
-     * @test
      */
     public function testSleep()
     {
@@ -81,8 +77,6 @@ class SleepEnvironmentBuilderTest extends TestCase
      * Tests usleep()
      *
      * @param int $microseconds Microseconds.
-     *
-     * @test
      * @dataProvider provideTestUsleep
      */
     public function testUsleep($microseconds)
@@ -113,8 +107,6 @@ class SleepEnvironmentBuilderTest extends TestCase
 
     /**
      * Tests date()
-     *
-     * @test
      */
     public function testDate()
     {

--- a/tests/functions/AbstractSleepFunctionTest.php
+++ b/tests/functions/AbstractSleepFunctionTest.php
@@ -16,8 +16,6 @@ class AbstractSleepFunctionTest extends TestCase
 {
     /**
      * Tests incrementation of all Incrementables
-     *
-     * @test
      */
     public function testSleepIncrementationOfAllIncrementables()
     {
@@ -37,8 +35,6 @@ class AbstractSleepFunctionTest extends TestCase
      * @param AbstractSleepFunction $sleepFunction Tested implementation.
      * @param int $amount                          Amount of time units.
      * @param mixed $expected                      Expected seconds.
-     *
-     * @test
      * @dataProvider provideTestSleepIncrementation
      */
     public function testSleepIncrementation(

--- a/tests/functions/FixedDateFunctionTest.php
+++ b/tests/functions/FixedDateFunctionTest.php
@@ -16,8 +16,6 @@ class FixedDateFunctionTest extends TestCase
 {
     /**
      * Tests getDate().
-     *
-     * @test
      */
     public function testGetDate()
     {

--- a/tests/functions/FixedMicrotimeFunctionTest.php
+++ b/tests/functions/FixedMicrotimeFunctionTest.php
@@ -17,8 +17,6 @@ class FixedMicrotimeFunctionTest extends TestCase
 {
     /**
      * Tests setMicrotime().
-     *
-     * @test
      */
     public function testSetMicrotime()
     {
@@ -29,8 +27,6 @@ class FixedMicrotimeFunctionTest extends TestCase
 
     /**
      * Tests setMicrotimeAsFloat().
-     *
-     * @test
      */
     public function testSetMicrotimeAsFloat()
     {
@@ -41,8 +37,6 @@ class FixedMicrotimeFunctionTest extends TestCase
 
     /**
      * Tests getMicrotime().
-     *
-     * @test
      */
     public function testGetMicrotime()
     {
@@ -54,8 +48,6 @@ class FixedMicrotimeFunctionTest extends TestCase
 
     /**
      * Tests getCallable()
-     *
-     * @test
      */
     public function testGetCallable()
     {
@@ -77,8 +69,6 @@ class FixedMicrotimeFunctionTest extends TestCase
 
     /**
      * Tests initializing with the current timestamp
-     *
-     * @test
      */
     public function testConstructCurrentTime()
     {
@@ -90,8 +80,6 @@ class FixedMicrotimeFunctionTest extends TestCase
 
     /**
      * Tests exception for invalid argument in constructor.
-     *
-     * @test
      * @dataProvider provideTestConstructFailsForInvalidArgument
      */
     public function testConstructFailsForInvalidArgument($timestamp)
@@ -118,8 +106,6 @@ class FixedMicrotimeFunctionTest extends TestCase
      *
      * @param mixed $timestamp The tested timestamp.
      * @param float $expected  The expected timestamp.
-     *
-     * @test
      * @dataProvider provideTestConstruct
      */
     public function testConstruct($timestamp, $expected)

--- a/tests/functions/IncrementableTest.php
+++ b/tests/functions/IncrementableTest.php
@@ -21,8 +21,6 @@ class IncrementableTest extends TestCase
      * @param mixed $increment              The amount of increase.
      * @param Incrementable $incrementable  The tested Incrementable.
      * @param callable $getValue            The lambda for getting the value.
-     *
-     * @test
      * @dataProvider provideTestIncrement
      */
     public function testIncrement(

--- a/tests/functions/MicrotimeConverterTest.php
+++ b/tests/functions/MicrotimeConverterTest.php
@@ -19,8 +19,6 @@ class MicrotimeConverterTest extends TestCase
      *
      * @param float  $float   The timestamp.
      * @param string $string  The timestamp.
-     *
-     * @test
      * @dataProvider provideFloatAndStrings
      */
     public function testConvertStringToFloat($float, $string)
@@ -34,8 +32,6 @@ class MicrotimeConverterTest extends TestCase
      *
      * @param float  $float   The timestamp.
      * @param string $string  The timestamp.
-     *
-     * @test
      * @dataProvider provideFloatAndStrings
      */
     public function testConvertFloatToString($float, $string)

--- a/tests/generator/MockFunctionGeneratorTest.php
+++ b/tests/generator/MockFunctionGeneratorTest.php
@@ -19,8 +19,6 @@ class MockFunctionGeneratorTest extends TestCase
      *
      * @param array $expected  The expected result.
      * @param array $arguments The input arguments.
-     *
-     * @test
      * @dataProvider provideTestRemoveDefaultArguments
      */
     public function testRemoveDefaultArguments(array $expected, array $arguments)

--- a/tests/generator/ParameterBuilderTest.php
+++ b/tests/generator/ParameterBuilderTest.php
@@ -22,7 +22,6 @@ class ParameterBuilderTest extends TestCase
      * @param string $function          The function name.
      *
      * @dataProvider provideTestBuild
-     * @test
      */
     public function testBuild($expectedSignature, $expectedBody, $function)
     {

--- a/tests/spy/SpyTest.php
+++ b/tests/spy/SpyTest.php
@@ -39,8 +39,6 @@ class SpyTest extends AbstractMockTestCase
      * @param array    $expected
      * @param string   $name
      * @param callable $invocations
-     *
-     * @test
      * @dataProvider provideTestGetInvocations
      */
     public function testGetInvocations(array $expected, $name, callable $invocations)
@@ -121,8 +119,6 @@ class SpyTest extends AbstractMockTestCase
 
     /**
      * Tests the default function.
-     *
-     * @test
      */
     public function testDefaultFunction()
     {
@@ -136,8 +132,6 @@ class SpyTest extends AbstractMockTestCase
 
     /**
      * An exception should still be recorded.
-     *
-     * @test
      */
     public function testException()
     {
@@ -160,8 +154,6 @@ class SpyTest extends AbstractMockTestCase
 
     /**
      * Test the invocation of a none exception call.
-     *
-     * @test
      */
     public function testNoException()
     {


### PR DESCRIPTION
See https://phpunit.de/announcements/phpunit-11.html

https://github.com/sebastianbergmann/phpunit/blob/11.0.0/ChangeLog-11.0.md#changes-in-phpunit-110

https://github.com/sebastianbergmann/php-text-template/blob/4.0.0/ChangeLog.md#400---2024-02-02

All metadoc throws deprecation warnings here, asking to use attributes. This will be a breaking change with PHPUnit 12 and then PHP 8 would need to be used a minimal dependency here I guess? But for now it should still be fine? See also test outputs starting with 8.2.
Or you/I bump to PHP 8 here already? :)

I can try to add support in the other packages too after this was released.

Also: it feels like the PHPUnit 10 support was just merged recently, but apparently it was already almost a year ago or so :)