### PR TITLE
Maintenance: support phpunit v12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     },
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
-        "phpunit/php-text-template": "^1 || ^2 || ^3 || ^4"
+        "phpunit/php-text-template": "^1 || ^2 || ^3 || ^4 || ^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
         "squizlabs/php_codesniffer": "^3.8"
     },
     "replace": {

--- a/tests/AbstractMockTestCase.php
+++ b/tests/AbstractMockTestCase.php
@@ -65,6 +65,7 @@ abstract class AbstractMockTestCase extends TestCase
      * Tests mocking a previously mocked function again.
      * @depends testMockFunctionWithoutParameters
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testMockFunctionWithoutParameters')]
     public function testRedefine()
     {
         $this->mockFunction(__NAMESPACE__, "getmyuid", function () {
@@ -175,6 +176,7 @@ abstract class AbstractMockTestCase extends TestCase
      * Tests that the disabled mock uses the default argument of the original function.
      * @depends testPreserveArgumentDefaultValue
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testPreserveArgumentDefaultValue')]
     public function testResetToDefaultArgumentOfOriginalFunction()
     {
         $functionName = $this->buildPrivateFunctionName("testPreserveArgumentDefaultValue");
@@ -197,6 +199,7 @@ abstract class AbstractMockTestCase extends TestCase
      * Tests some methods which use the varname "..." after a mock was defined.
      * @depends testCVariadic
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testCVariadic')]
     public function testCVariadicReset()
     {
         $this->assertEquals(1, min(2, 1));
@@ -222,6 +225,7 @@ abstract class AbstractMockTestCase extends TestCase
      * Tests disable().
      * @depends testDisableSetup
      */
+    #[\PHPUnit\Framework\Attributes\Depends('testDisableSetup')]
     public function testDisable()
     {
         $this->assertNotEquals(1234, rand());
@@ -284,6 +288,8 @@ abstract class AbstractMockTestCase extends TestCase
      * @backupStaticAttributes
      * @dataProvider provideTestBackupStaticAttributes
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestBackupStaticAttributes')]
+    #[\PHPUnit\Framework\Attributes\BackupStaticProperties(true)]
     public function testBackupStaticAttributes()
     {
         $this->mockFunction(__NAMESPACE__, "testBackupStaticAttributes", "sqrt");
@@ -306,6 +312,7 @@ abstract class AbstractMockTestCase extends TestCase
      * Tests the mock in a separate process.
      * @runInSeparateProcess
      */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testRunInSeparateProcess()
     {
         $this->mockFunction(__NAMESPACE__, "time", function () {

--- a/tests/MockCaseInsensitivityTest.php
+++ b/tests/MockCaseInsensitivityTest.php
@@ -34,6 +34,7 @@ class MockCaseInsensitivityTest extends TestCase
      *
      * @dataProvider provideTestCaseSensitivity
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestCaseSensitivity')]
     public function testFailEnable($mockName)
     {
         $builder = new MockBuilder();
@@ -55,6 +56,7 @@ class MockCaseInsensitivityTest extends TestCase
      * @param string $mockName  The mock function name.
      * @dataProvider provideTestCaseSensitivity
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestCaseSensitivity')]
     public function testCaseSensitivity($mockName)
     {
         $builder = new MockBuilder();

--- a/tests/MockNamespaceTest.php
+++ b/tests/MockNamespaceTest.php
@@ -52,6 +52,7 @@ class MockNamespaceTest extends TestCase
      * @dataprovider provideTestNamespace
      * @runInSeparateProcess
      */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testDefiningNamespaces()
     {
         $this->builder->setNamespace(__NAMESPACE__);

--- a/tests/environment/SleepEnvironmentBuilderTest.php
+++ b/tests/environment/SleepEnvironmentBuilderTest.php
@@ -79,6 +79,7 @@ class SleepEnvironmentBuilderTest extends TestCase
      * @param int $microseconds Microseconds.
      * @dataProvider provideTestUsleep
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestUsleep')]
     public function testUsleep($microseconds)
     {
         $time = time();

--- a/tests/functions/AbstractSleepFunctionTest.php
+++ b/tests/functions/AbstractSleepFunctionTest.php
@@ -37,6 +37,7 @@ class AbstractSleepFunctionTest extends TestCase
      * @param mixed $expected                      Expected seconds.
      * @dataProvider provideTestSleepIncrementation
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestSleepIncrementation')]
     public function testSleepIncrementation(
         AbstractSleepFunction $sleepFunction,
         $amount,

--- a/tests/functions/FixedMicrotimeFunctionTest.php
+++ b/tests/functions/FixedMicrotimeFunctionTest.php
@@ -82,6 +82,7 @@ class FixedMicrotimeFunctionTest extends TestCase
      * Tests exception for invalid argument in constructor.
      * @dataProvider provideTestConstructFailsForInvalidArgument
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestConstructFailsForInvalidArgument')]
     public function testConstructFailsForInvalidArgument($timestamp)
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -108,6 +109,7 @@ class FixedMicrotimeFunctionTest extends TestCase
      * @param float $expected  The expected timestamp.
      * @dataProvider provideTestConstruct
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestConstruct')]
     public function testConstruct($timestamp, $expected)
     {
         $function = new FixedMicrotimeFunction($timestamp);

--- a/tests/functions/IncrementableTest.php
+++ b/tests/functions/IncrementableTest.php
@@ -23,6 +23,7 @@ class IncrementableTest extends TestCase
      * @param callable $getValue            The lambda for getting the value.
      * @dataProvider provideTestIncrement
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestIncrement')]
     public function testIncrement(
         $expected,
         $increment,

--- a/tests/functions/MicrotimeConverterTest.php
+++ b/tests/functions/MicrotimeConverterTest.php
@@ -21,6 +21,7 @@ class MicrotimeConverterTest extends TestCase
      * @param string $string  The timestamp.
      * @dataProvider provideFloatAndStrings
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFloatAndStrings')]
     public function testConvertStringToFloat($float, $string)
     {
         $converter = new MicrotimeConverter();
@@ -34,6 +35,7 @@ class MicrotimeConverterTest extends TestCase
      * @param string $string  The timestamp.
      * @dataProvider provideFloatAndStrings
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFloatAndStrings')]
     public function testConvertFloatToString($float, $string)
     {
         $converter = new MicrotimeConverter();

--- a/tests/generator/MockFunctionGeneratorTest.php
+++ b/tests/generator/MockFunctionGeneratorTest.php
@@ -21,6 +21,7 @@ class MockFunctionGeneratorTest extends TestCase
      * @param array $arguments The input arguments.
      * @dataProvider provideTestRemoveDefaultArguments
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestRemoveDefaultArguments')]
     public function testRemoveDefaultArguments(array $expected, array $arguments)
     {
         MockFunctionGenerator::removeDefaultArguments($arguments);

--- a/tests/generator/ParameterBuilderTest.php
+++ b/tests/generator/ParameterBuilderTest.php
@@ -23,6 +23,7 @@ class ParameterBuilderTest extends TestCase
      *
      * @dataProvider provideTestBuild
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestBuild')]
     public function testBuild($expectedSignature, $expectedBody, $function)
     {
         $builder = new ParameterBuilder();

--- a/tests/spy/SpyTest.php
+++ b/tests/spy/SpyTest.php
@@ -41,6 +41,7 @@ class SpyTest extends AbstractMockTestCase
      * @param callable $invocations
      * @dataProvider provideTestGetInvocations
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestGetInvocations')]
     public function testGetInvocations(array $expected, $name, callable $invocations)
     {
         $spy = new Spy(__NAMESPACE__, $name);


### PR DESCRIPTION
- support new version `phpunit/php-text-template` (^5);
- support new version `phpunit/phpunit` (^12.0);
- add attributes for each annotations for support of phpunit 12;